### PR TITLE
Add rule to alert to many uaa accounts created past week

### DIFF
--- a/bosh/README.md
+++ b/bosh/README.md
@@ -152,6 +152,14 @@ https://github.com/18F/cg-deploy-prometheus/blob/master/bosh/opsfiles/rules.yml#
 ### Guidance:
 UAA Client audits have not run in this environment for more then 2 hours. Check recent builds for `uaa-client-audit-*` in https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cf-deployment for more details.
 
+## UAAMonitorAccountCreation
+### Source data:
+https://github.com/cloud-gov/cg-deploy-cf/blob/master/ci/uaa-monitor-account-creation.sh
+### Rule body:
+https://github.com/cloud-gov/cg-deploy-prometheus/blob/master/bosh/opsfiles/rules.yml#L261
+### Guidance:
+UAA Monitor Account Creation monitors the number of new accounts in the past week and alerts if there are more than 50. Check recent builds for `uaa-monitor-account-creation` in https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cf-deployment for more details.
+
 ## Prometheus seems to be down or hung!
 ### Source data:
 https://github.com/18F/cg-deploy-cf/blob/master/ci/prometheus-down.sh

--- a/bosh/README.md
+++ b/bosh/README.md
@@ -158,7 +158,7 @@ https://github.com/cloud-gov/cg-deploy-cf/blob/master/ci/uaa-monitor-account-cre
 ### Rule body:
 https://github.com/cloud-gov/cg-deploy-prometheus/blob/master/bosh/opsfiles/rules.yml#L261
 ### Guidance:
-UAA Monitor Account Creation monitors the number of new accounts in the past week and alerts if there are more than 50. Check recent builds for `uaa-monitor-account-creation` in https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cf-deployment for more details.
+UAA Monitor Account Creation monitors the number of new accounts in the past four days and alerts if there are more than 50. Check recent builds for `uaa-monitor-account-creation` in https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cf-deployment for more details.
 
 ## Prometheus seems to be down or hung!
 ### Source data:

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -258,6 +258,22 @@
         summary: UAA Client Audit has not run in two hours
         description: Check https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cf-deployment for failures
 
+# UAA Monitor Account Creation alerts
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: uaa-monitor-account-creation
+    rules:
+    - alert: UAAMonitorAccountCreation
+      expr: uaa_monitor_account_creation > 50
+      labels:
+        service: uaa-monitor-account-creation
+        severity: warning
+        uaa: '{{$labels.uaa_url}}'
+      annotations:
+        summary: UAA has created more accounts than expected in the past week for {{$labels.uaa_url}}.
+        description: UAA has created many more new accounts than normal. Verify the spike in new UAA accounts are legitimate.
+
 # Concourse alerts
 - type: replace
   path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
@@ -368,16 +384,16 @@
         summary: Burst in incoming network traffic
         description: "The platform has seen a very large burst in incoming network traffic, please review this dashboard: https://grafana.fr.cloud.gov/d/cf_router/cf-router"
 
-- type: replace	
-  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-	
-  value:	
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
     name: aide
-    rules:	
+    rules:
     - alert: AideViolations
-      expr: aide_violation_count > 0	
-      labels:	
-        service: aide	
-        severity: warning	
-      annotations:	
-        summary: 'AIDE found violations for {{$labels.instance}}, with action {{$labels.action}}'	
+      expr: aide_violation_count > 0
+      labels:
+        service: aide
+        severity: warning
+      annotations:
+        summary: 'AIDE found violations for {{$labels.instance}}, with action {{$labels.action}}'
         description: Review AIDE report in logs-platform - if changes are expected, update AIDE database on alerting VM

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -271,7 +271,7 @@
         severity: warning
         uaa: '{{$labels.uaa_url}}'
       annotations:
-        summary: UAA has created more accounts than expected in the past week for {{$labels.uaa_url}}.
+        summary: UAA has created more accounts than expected in the past four days for {{$labels.uaa_url}}.
         description: UAA has created many more new accounts than normal. Verify the spike in new UAA accounts are legitimate.
 
 # Concourse alerts


### PR DESCRIPTION
Requires https://github.com/cloud-gov/cg-deploy-cf/pull/501 to function

## Changes proposed in this pull request:
- Added a new alert for UAA Account Creation in the past week
- A waring alert is thrown when more the 50 accounts are created in the past 7 days
  - A quick look and we've been averaging ~20 new users/week so we may want to adjust 🤷 
- Keeps parity with the UAA Client Audit by running the alert jobs from cf-deploy
  - The ci job runs hourly

## security considerations
- none
