### PR TITLE
make sure metrics are unique

### DIFF
--- a/ci/domain-broker-certs.sh
+++ b/ci/domain-broker-certs.sh
@@ -20,6 +20,7 @@ done
 nlbs=0
 ncerts=0
 cert_names=""
+cert_expirations=""
 for lb_arn in "${lb_arns[@]}"; do
   lb_listener_arns=$(aws elbv2 describe-listeners --load-balancer-arn "${lb_arn}" \
       | jq -r ".Listeners[] | select(.Port == 443) | .ListenerArn")
@@ -27,18 +28,18 @@ for lb_arn in "${lb_arns[@]}"; do
     nlbs=$((nlbs + 1))
     certs_listener=$(aws elbv2 describe-listener-certificates --listener-arn "${lb_listener_arn}")
     cert_names="${cert_names}"$'\n'"$(echo ${certs_listener} | jq -r '.Certificates[] | .CertificateArn'  | awk -F/ '{ print $NF }')"
+      for cert_name in ${cert_names}; do
+        cert_metadata=$(aws iam get-server-certificate --server-certificate-name ${cert_name})
+        cert_date=$(echo "${cert_metadata}" | jq -r '.ServerCertificate | .ServerCertificateMetadata | .Expiration')
+        cert_expiration=$(gdate --date "${cert_date}" +%s)
+        cert_expirations="${cert_expirations}"$'\n'"domain_broker_certificate_expiration{certificate_name=\"${cert_name}\",listener_arn=\"${lb_listener_arn}\"} ${cert_expiration}"
+      done
     ncerts_listener=$(echo "${certs_listener}" | jq -r ".Certificates | length")
     ncerts=$((ncerts + ncerts_listener))
   done
 done
-cert_expirations=""
-for cert_name in ${cert_names}; do
-  cert_metadata=$(aws iam get-server-certificate --server-certificate-name ${cert_name})
-  cert_date=$(echo "${cert_metadata}" | jq -r '.ServerCertificate | .ServerCertificateMetadata | .Expiration')
-  cert_expiration=$(date --date "${cert_date}" +%s)
-  cert_expirations="${cert_expirations}"$'\n'"domain_broker_certificate_expiration{certificate_name=\"${cert_name}\"} ${cert_expiration}"
-done
 
+cert_expirations=$(echo "${cert_expirations}" | sort | uniq)
 cat <<EOF | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/domain_broker/instance/${ENVIRONMENT}"
 domain_broker_listener_count ${nlbs}
 domain_broker_certificate_count ${ncerts}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Make sure metrics have unique labels. On the version of pushgateway we run, you can push 2 metrics at the same time with the same name an same set of labels, but then pushgateway breaks and you become sad. This prevents that by adding the listener_arn to the metric, then de-duping the metrics before pushing them.

See slack thread before merging.

## security considerations
None