### PR TITLE
Add alert for CDN cert expiration

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -311,7 +311,7 @@
         severity: warning
       annotations:
         summary: 'External domain broker has too few available certificates: {{$value}}'
-        description: Provision more load balancers for domain broker in Terraform and update external-domain-broker config with new ALB 
+        description: Provision more load balancers for domain broker in Terraform and update external-domain-broker config with new ALB
     - alert: DomainBrokerFullALB
       expr: alb_listener_certificate_count > 23
       labels:
@@ -419,4 +419,18 @@
         severity: critical
       annotations:
         summary: '{{$labels.certificate_name}}, expires in less than 15 days. Days until expiration: {{$labels.value}}'
-        description: Find out why the certificate is not renewing. The service instance ID is probably in the certificate name. 
+        description: Find out why the certificate is not renewing. The service instance ID is probably in the certificate name.
+
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: cdn-certificate-expiration
+    rules:
+    - alert: CDNCertificateExpiring
+      expr: cdn_certificate_expiration < 15
+      labels:
+        service: CDN
+        severity: critical
+      annotations:
+        summary: '{{$labels.arn}} with domain {{$labels.alias}}, expires in less than 15 days. Days until expiration: {{$labels.value}}'
+        description: Find out why the certificate is not renewing. The CloudFront instance ID is {{$labels.id}}.

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -432,5 +432,5 @@
         service: CDN
         severity: critical
       annotations:
-        summary: '{{$labels.arn}} with domain {{$labels.alias}}, expires in less than 15 days. Days until expiration: {{$labels.value}}'
-        description: Find out why the certificate is not renewing. The CloudFront instance ID is {{$labels.id}}.
+        summary: '{{$labels.arn}} with alias {{$labels.alias}} and cloudfront domain {{$labels.domain}}, expires in less than 15 days. Days until expiration: {{$labels.value}}'
+        description: 'Find out why the certificate is not renewing. The CloudFront instance ID is {{$labels.id}}.'

--- a/ci/cdn-broker-certs.sh
+++ b/ci/cdn-broker-certs.sh
@@ -4,11 +4,12 @@ set -euxo pipefail
 
 ## Calculate the days to expiration from now
 function days_to_cert_expiration {
-  local target=$1;
-  local date_today=$(date +%s)
+  local client=$1;
+  local server=$2;
+  local date_today=$(date +%s);
 
   ## Get expirationdate and convert to epoch
-  expirationdate=$(date -d "$(: | openssl s_client -connect $target:443 -servername $target 2>/dev/null \
+  expirationdate=$(date -d "$(: | openssl s_client -connect $client:443 -servername $server 2>/dev/null \
     | openssl x509 -text \
     | grep 'Not After' \
     | awk '{print $4,$5,$7}')" '+%s');
@@ -29,22 +30,24 @@ function days_to_cert_expiration {
 
 ## Select and get Cloudfront instances returning ARN, & Aliases
 alias_count=0
-cdns_selector='.DistributionList.Items[] | select(.Aliases.Items != null) | {id:.Id,arn:.ARN,aliases:.Aliases.Items}'
+cdn_count=0
+cdns_selector='.DistributionList.Items[] | select(.Aliases.Items != null) | {id:.Id,arn:.ARN,aliases:.Aliases.Items,domain:.DomainName}'
 cdns=$(aws cloudfront list-distributions | jq -c "${cdns_selector}")
-cdn_count=$(echo $cdn | jq -r "length")
 cdn_list=($cdns)
 
 ## Loop through list of CDN instances
 cdn_certificate_expirations=""
 for cdn in "${cdn_list[@]}"; do
+  cdn_count=$((cdn_count + 1))
   aliases=($(echo $cdn | jq -r ".aliases[]"))
   arn=($(echo $cdn | jq -r ".arn"))
+  domain=($(echo $cdn | jq -r ".domain"))
   id=($(echo $cdn | jq -r ".id"))
 
   for alias in "${aliases[@]}"; do
     alias_count=$((alias_count + 1))
-    days_to_expire=$(days_to_cert_expiration $alias)
-    cdn_certificate_expirations="${cdn_certificate_expirations}"$'\n'"cdn_certificate_expiration{id=\"${id}\",arn=\"${arn}\",alias=\"${alias}\"} ${days_to_expire}"
+    days_to_expire=$(days_to_cert_expiration $domain $alias)
+    cdn_certificate_expirations="${cdn_certificate_expirations}"$'\n'"cdn_certificate_expiration{id=\"${id}\",arn=\"${arn}\",alias=\"${alias}\",domain=\"${domain}\"} ${days_to_expire}"
   done
 done
 

--- a/ci/cdn-broker-certs.sh
+++ b/ci/cdn-broker-certs.sh
@@ -4,12 +4,12 @@ set -euxo pipefail
 
 ## Calculate the days to expiration from now
 function days_to_cert_expiration {
-  local client=$1;
-  local server=$2;
+  local cloudfront=$1;
+  local alias=$2;
   local date_today=$(date +%s);
 
   ## Get expirationdate and convert to epoch
-  expirationdate=$(date -d "$(: | openssl s_client -connect $client:443 -servername $server 2>/dev/null \
+  expirationdate=$(date -d "$(: | openssl s_client -connect $cloudfront:443 -servername $alias 2>/dev/null \
     | openssl x509 -text \
     | grep 'Not After' \
     | awk '{print $4,$5,$7}')" '+%s');

--- a/ci/cdn-broker-certs.sh
+++ b/ci/cdn-broker-certs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+## Calculate the days to expiration from now
+function days_to_cert_expiration {
+  local target=$1;
+  local date_today=$(date +%s)
+
+  ## Get expirationdate and convert to epoch
+  expirationdate=$(date -d "$(: | openssl s_client -connect $target:443 -servername $target 2>/dev/null \
+    | openssl x509 -text \
+    | grep 'Not After' \
+    | awk '{print $4,$5,$7}')" '+%s');
+
+  ## Check the seconds to expiration from now
+  seconds_to_go=$(expr $expirationdate - $date_today)\
+
+  if ! [[ $seconds_to_go -gt 0 ]]; then
+    ## Return integer less than or equal to 0
+    seconds_past=$(expr $date_today - $expirationdate)
+    negative_days=$(($seconds_past / 86400))
+    echo $((0 - $negative_days))
+  else
+     ## Return integer greater than or equal to 0
+    echo $(($seconds_to_go / 86400))
+  fi
+}
+
+## Select and get Cloudfront instances returning ARN, & Aliases
+alias_count=0
+cdns_selector='.DistributionList.Items[] | select(.Aliases.Items != null) | {id:.Id,arn:.ARN,aliases:.Aliases.Items}'
+cdns=$(aws cloudfront list-distributions | jq -c "${cdns_selector}")
+cdn_count=$(echo $cdn | jq -r "length")
+cdn_list=($cdns)
+
+## Loop through list of CDN instances
+cdn_certificate_expirations=""
+for cdn in "${cdn_list[@]}"; do
+  aliases=($(echo $cdn | jq -r ".aliases[]"))
+  arn=($(echo $cdn | jq -r ".arn"))
+  id=($(echo $cdn | jq -r ".id"))
+
+  for alias in "${aliases[@]}"; do
+    alias_count=$((alias_count + 1))
+    days_to_expire=$(days_to_cert_expiration $alias)
+    cdn_certificate_expirations="${cdn_certificate_expirations}"$'\n'"cdn_certificate_expiration{id=\"${id}\",arn=\"${arn}\",alias=\"${alias}\"} ${days_to_expire}"
+  done
+done
+
+## Create and post to prometheus
+cat <<EOF | curl --data-binary @- "${GATEWAY_HOST}:${GATEWAY_PORT:-9091}/metrics/job/domain_broker/instance/${ENVIRONMENT}"
+cdn_instance_count ${cdn_count}
+cdn_alias_count ${alias_count}
+${cdn_certificate_expirations}
+EOF

--- a/ci/cdn-broker-certs.yml
+++ b/ci/cdn-broker-certs.yml
@@ -1,0 +1,19 @@
+---
+  platform: linux
+  image_resource:
+    type: docker-image
+    source:
+      repository: 18fgsa/concourse-task
+
+  inputs:
+  - {name: prometheus-config}
+
+  run:
+    path: prometheus-config/ci/cdn-broker-certs.sh
+
+  params:
+    AWS_DEFAULT_REGION:
+    AWS_ACCESS_KEY_ID:
+    AWS_SECRET_ACCESS_KEY:
+    ENVIRONMENT:
+    GATEWAY_HOST:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -9,6 +9,7 @@ groups:
   - awslogs-check
   - aws-mfa-check
   - aws-rds-storage-check
+  - cdn-broker-certs
   - domain-broker-certs
   - concourse-has-auth-check
   - prometheus-down-check-staging
@@ -61,6 +62,24 @@ jobs:
     params:
       AWS_DEFAULT_REGION: ((aws-region))
       GATEWAY_HOST: prometheus-production.service.cf.internal
+
+- name: cdn-broker-certs
+  serial_groups: [production]
+  plan:
+  - in_parallel:
+    - get: prometheus-check-timer
+      trigger: true
+    - get: prometheus-config
+      resource: prometheus-config
+  - in_parallel:
+    - task: cdn-broker-certs-production
+      file: prometheus-config/ci/cdn-broker-certs.yml
+      params:
+        AWS_DEFAULT_REGION: ((aws-external-region))
+        AWS_ACCESS_KEY_ID: ((aws-external-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((aws-external-secret-access-key))
+        ENVIRONMENT: production
+        GATEWAY_HOST: prometheus-production.service.cf.internal
 
 - name: domain-broker-certs
   serial_groups: [production]


### PR DESCRIPTION
Closes #144 

## Changes proposed in this pull request:
- [x] Add rule for CDN certificate expirtation
- [x] Add CI task `cdn-broker-certs`
- [x] Add script to check CDN certs
- [x] Create AWS user to list CDN descriptions (add or update IAM user in [cg-provision](https://github.com/cloud-gov/cg-provision)) ((see PR#791)[https://github.com/cloud-gov/cg-provision/pull/791])

## security considerations
- none
