### PR TITLE
moving release to use secureproxy up front

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -5,6 +5,7 @@ releases:
 - {name: oauth2-proxy, version: latest}
 - {name: cron, version: latest}
 - {name: bosh-dns-aliases, version: latest}
+- {name: secureproxy, version: latest}
 
 stemcells:
 - alias: default
@@ -336,24 +337,24 @@ instance_groups:
     properties:
       nginx:
         prometheus:
-          http_port: 8081
+          http_port: 8082
           server_name: prometheus.((domain))
           headers: &security-headers
             X-Frame-Options: DENY
             Strict-Transport-Security: "max-age=31536000; preload"
         alertmanager:
-          http_port: 8081
+          http_port: 8082
           server_name: alertmanager.((domain))
           headers: *security-headers
         grafana:
-          http_port: 8081
+          http_port: 8082
           server_name: grafana.((domain))
           headers: *security-headers
   - name: oauth2-proxy
     release: oauth2-proxy
     properties:
-      address: http://0.0.0.0:8080
-      upstream: http://127.0.0.1:8081
+      address: http://0.0.0.0:8081
+      upstream: http://127.0.0.1:8082
       provider: oidc
       client_id: ((oauth-proxy-client-id))
       client_secret: ((oauth-proxy-client-secret))
@@ -362,6 +363,12 @@ instance_groups:
       email_domain: gsa.gov
       browser_xss_filter: True
       content_type_nosniff: True
+  - name: secureproxy
+    properties:
+      secureproxy:
+        listen_port: 8080
+        proxy_port: 8081
+    release: secureproxy
 variables:
 - name: grafana-admin-password
   type: password

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -209,7 +209,7 @@ jobs:
       releases:
       - prometheus-release/*.tgz
       - oauth2-proxy-release/*.tgz
-      - secureproxy-release
+      - secureproxy-release/*.tgz
       stemcells:
       - prometheus-stemcell-bionic/*.tgz
       ops_files:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -198,6 +198,8 @@ jobs:
       trigger: true
     - get: prometheus-stemcell-bionic
       trigger: true
+    - get: secureproxy-release
+      trigger: true
     - get: pipeline-tasks
     - get: terraform-staging-yml
   - put: prometheus-staging-deployment
@@ -207,6 +209,7 @@ jobs:
       releases:
       - prometheus-release/*.tgz
       - oauth2-proxy-release/*.tgz
+      - secureproxy-release
       stemcells:
       - prometheus-stemcell-bionic/*.tgz
       ops_files:
@@ -253,6 +256,9 @@ jobs:
       passed: [deploy-prometheus-staging]
       trigger: true
     - get: prometheus-stemcell-bionic
+      passed: [deploy-prometheus-staging]
+      trigger: true
+    - get: secureproxy-release
       passed: [deploy-prometheus-staging]
       trigger: true
     - get: pipeline-tasks
@@ -323,6 +329,13 @@ resources:
     bucket: ((s3-bosh-releases-bucket))
     regexp: oauth2-proxy-(.*).tgz
     region_name: ((aws-region))
+
+- name: secureproxy-release
+  source:
+    bucket: ((s3-bosh-releases-bucket))
+    regexp: secureproxy-(.*).tgz
+    region_name: ((aws-region))
+  type: s3-iam
 
 - name: prometheus-config
   icon: github-circle


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move oauth/nginx ports down one for secureproxy
- Add in secureproxy up front

## security considerations
By using secureproxy up front we help to secure the platform
