### PR TITLE
Move non-sensitive values to config and self-fly pipeline

### DIFF
--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,0 +1,13 @@
+cg-deploy-prometheus-staging-git-branch: main
+cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
+cg-deploy-prometheus-git-branch: main
+cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
+
+prometheus-release-git-branch: master
+prometheus-release-version-filter: v27.*
+prometheus-release-git-url: https://github.com/bosh-prometheus/prometheus-boshrelease
+
+pipeline-tasks-git-branch: master
+pipeline-tasks-git-url: https://github.com/cloud-gov/cg-pipeline-tasks.git
+
+slack-icon-url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,6 +16,14 @@ groups:
   - prometheus-down-check-production
 
 jobs:
+- name: set-self
+  plan:
+    - get: cg-deploy-prometheus
+      trigger: true
+    - set_pipeline: self
+      file: cg-deploy-prometheus/ci/pipeline.yml
+      var_files:
+        - cg-deploy-prometheus/ci/config.yml
 - name: awslogs-check
   serial_groups: [production]
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,6 +6,7 @@ groups:
   - deploy-prometheus-production
 - name: checks
   jobs:
+  - set-self
   - awslogs-check
   - aws-mfa-check
   - aws-rds-storage-check
@@ -18,12 +19,13 @@ groups:
 jobs:
 - name: set-self
   plan:
-    - get: cg-deploy-prometheus
+    - get: prometheus-config
       trigger: true
     - set_pipeline: self
-      file: cg-deploy-prometheus/ci/pipeline.yml
+      file: prometheus-config/ci/pipeline.yml
       var_files:
-        - cg-deploy-prometheus/ci/config.yml
+        - prometheus-config/ci/config.yml
+
 - name: awslogs-check
   serial_groups: [production]
   plan:
@@ -31,7 +33,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
-      resource: prometheus-config
+      passed: [set-self]
   - task: awslogs
     file: prometheus-config/ci/awslogs.yml
     tags: [iaas]
@@ -47,7 +49,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
-      resource: prometheus-config
+      passed: [set-self]
   - task: aws-rds-storage-check
     file: prometheus-config/ci/aws-rds-storage.yml
     params:
@@ -63,7 +65,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
-      resource: prometheus-config
+      passed: [set-self]
   - task: aws-mfa
     file: prometheus-config/ci/aws-mfa.yml
     tags: [iaas]
@@ -78,7 +80,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
-      resource: prometheus-config
+      passed: [set-self]
   - in_parallel:
     - task: cdn-broker-certs-production
       file: prometheus-config/ci/cdn-broker-certs.yml
@@ -96,7 +98,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
-      resource: prometheus-config
+      passed: [set-self]
   - in_parallel:
     - task: domain-broker-certs-development
       file: prometheus-config/ci/domain-broker-certs.yml
@@ -130,7 +132,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
-      resource: prometheus-config
+      passed: [set-self]
   - task: concourse-has-auth
     file: prometheus-config/ci/concourse-has-auth.yml
     params:
@@ -144,6 +146,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
+      passed: [set-self]
   - task: prometheus-down
     file: prometheus-config/ci/prometheus-down.yml
     params:
@@ -170,6 +173,7 @@ jobs:
     - get: prometheus-check-timer
       trigger: true
     - get: prometheus-config
+      passed: [set-self]
   - task: prometheus-down
     file: prometheus-config/ci/prometheus-down.yml
     params:
@@ -195,6 +199,7 @@ jobs:
   - in_parallel:
     - get: master-bosh-root-cert
     - get: prometheus-config
+      passed: [set-self]
       trigger: true
     - get: common-staging
       trigger: true
@@ -253,7 +258,7 @@ jobs:
   - in_parallel:
     - get: master-bosh-root-cert
     - get: prometheus-config
-      passed: [deploy-prometheus-staging]
+      passed: [deploy-prometheus-staging, set-self]
       trigger: true
     - get: common-production
       trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move non-sensitive config values to config.yml.
- Simplify pipeline updates with self-setting pipeline.

## security considerations
This PR improves security by making it unnecessary for developers to pull credentials onto their personal machines to re-fly the pipeline.

Addresses https://github.com/cloud-gov/product/issues/2081
