### PR TITLE
Add alert for duplicate certificates

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -244,6 +244,14 @@
       annotations:
         summary: 'Alb listener {{$labels.alb_arn}} has too many certificates'
         description: "If DomainBrokerNotEnoughALBs isn't firing, the external-domain-broker is probably either placing instances incorrectly or not cleaning up certificates."
+    - alert: DomainBrokerMultipleServiceCertificates
+      expr: service_instance_cert_count > 1
+      labels:
+        service: domain-broker
+        severity: warning
+      annotations:
+        summary: 'Service instance {{$labels.service_instance_id}} has too many certificates'
+        description: "There are multiple certificates for the given service instance."
 
 - type: replace
   path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -244,7 +244,7 @@
       annotations:
         summary: 'Alb listener {{$labels.alb_arn}} has too many certificates'
         description: "If DomainBrokerNotEnoughALBs isn't firing, the external-domain-broker is probably either placing instances incorrectly or not cleaning up certificates."
-    - alert: DomainBrokerMultipleServiceCertificates
+    - alert: DomainBrokerServiceMultipleCertificates
       expr: service_instance_cert_count > 1
       labels:
         service: domain-broker


### PR DESCRIPTION
## Changes proposed in this pull request:

- add alert for detecting multiple certificates for a brokered domain instance

## security considerations

There shouldn't be any changes to security. We are just adding a new alert for insight into our system
