### PR TITLE
Fix duplicate cert alert

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -245,7 +245,7 @@
         summary: 'Alb listener {{$labels.alb_arn}} has too many certificates'
         description: "If DomainBrokerNotEnoughALBs isn't firing, the external-domain-broker is probably either placing instances incorrectly or not cleaning up certificates."
     - alert: DomainBrokerServiceMultipleCertificates
-      expr: service_instance_cert_count > 1
+      expr: service_instance_duplicate_cert_count > 0
       labels:
         service: domain-broker
         severity: warning


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix duplicate cert alert to identify any services with any duplicate certs (> 0), rather than services with more than one (> 1) duplicate certs

## security considerations

None
