### PR TITLE
Update to use Jammy stemcells

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -9,7 +9,7 @@ releases:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 update:

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,5 +1,4 @@
-#cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
-cg-deploy-prometheus-staging-git-branch: main
+cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 cg-deploy-prometheus-git-branch: main

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,6 +1,3 @@
-cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
-cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
-
 cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -2,7 +2,7 @@
 cg-deploy-prometheus-staging-git-branch: main
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 # cg-deploy-prometheus-git-branch: test-deploy-jammy
-cg-deploy-prometheus-git-branch: test-deploy-jammy
+cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: master

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,6 +1,8 @@
-cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
+#cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
+cg-deploy-prometheus-staging-git-branch: main
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
-cg-deploy-prometheus-git-branch: test-deploy-jammy
+# cg-deploy-prometheus-git-branch: test-deploy-jammy
+cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: master

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,4 +1,4 @@
-cg-deploy-prometheus-staging-git-branch: main
+cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,4 +1,4 @@
-cg-deploy-prometheus-git-branch: test-deploy-jammy
+cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: master

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -2,7 +2,7 @@
 cg-deploy-prometheus-staging-git-branch: main
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 # cg-deploy-prometheus-git-branch: test-deploy-jammy
-cg-deploy-prometheus-git-branch: main
+cg-deploy-prometheus-git-branch: test-deploy-jammy
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: master

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,6 +1,6 @@
 cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
-cg-deploy-prometheus-git-branch: main
+cg-deploy-prometheus-git-branch: test-deploy-jammy
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: master

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,6 +1,6 @@
 cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
-cg-deploy-prometheus-git-branch: main
+cg-deploy-prometheus-git-branch: test-deploy-jammy
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: test-deploy-jammy

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -3,11 +3,11 @@ cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-pro
 cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
-prometheus-release-git-branch: master
+prometheus-release-git-branch: test-deploy-jammy
 prometheus-release-version-filter: v27.*
 prometheus-release-git-url: https://github.com/bosh-prometheus/prometheus-boshrelease
 
-pipeline-tasks-git-branch: master
+pipeline-tasks-git-branch: test-deploy-jammy
 pipeline-tasks-git-url: https://github.com/cloud-gov/cg-pipeline-tasks.git
 
 slack-icon-url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,7 +1,7 @@
 #cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
 cg-deploy-prometheus-staging-git-branch: main
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
-# cg-deploy-prometheus-git-branch: test-deploy-jammy
+
 cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,13 +1,13 @@
 cg-deploy-prometheus-staging-git-branch: test-deploy-jammy
 cg-deploy-prometheus-staging-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
-cg-deploy-prometheus-git-branch: test-deploy-jammy
+cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
-prometheus-release-git-branch: test-deploy-jammy
+prometheus-release-git-branch: master
 prometheus-release-version-filter: v27.*
 prometheus-release-git-url: https://github.com/bosh-prometheus/prometheus-boshrelease
 
-pipeline-tasks-git-branch: test-deploy-jammy
+pipeline-tasks-git-branch: master
 pipeline-tasks-git-url: https://github.com/cloud-gov/cg-pipeline-tasks.git
 
 slack-icon-url: https://avatars1.githubusercontent.com/u/7809479?v=3&s=40

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,4 +1,4 @@
-cg-deploy-prometheus-git-branch: main
+cg-deploy-prometheus-git-branch: test-deploy-jammy
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: master

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -269,7 +269,7 @@ jobs:
     - get: oauth2-proxy-release
       passed: [deploy-prometheus-staging]
       trigger: true
-    - get: prometheus-stemcell-bionic
+    - get: prometheus-stemcell-jammy
       passed: [deploy-prometheus-staging]
       trigger: true
     - get: secureproxy-release
@@ -368,10 +368,10 @@ resources:
     # we can't upgrade past this until k8s is upgraded.
     tag_filter: ((prometheus-release-version-filter))
 
-- name: prometheus-stemcell-bionic
-  type: bosh-io-stemcell
-  source:
-    name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
+#- name: prometheus-stemcell-bionic
+#  type: bosh-io-stemcell
+#  source:
+#    name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
 
 - name: prometheus-stemcell-jammy
   type: bosh-io-stemcell

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -368,11 +368,6 @@ resources:
     # we can't upgrade past this until k8s is upgraded.
     tag_filter: ((prometheus-release-version-filter))
 
-#- name: prometheus-stemcell-bionic
-#  type: bosh-io-stemcell
-#  source:
-#    name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
-
 - name: prometheus-stemcell-jammy
   type: bosh-io-stemcell
   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -355,6 +355,7 @@ resources:
   icon: github-circle
   type: git
   source:
+    #uri: ((cg-deploy-prometheus-git-url))
     uri: ((cg-deploy-prometheus-git-url))
     branch: test-deploy-jammy
     commit_verification_keys: ((cloud-gov-pgp-keys))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -356,7 +356,7 @@ resources:
   type: git
   source:
     uri: ((cg-deploy-prometheus-git-url))
-    branch: ((cg-deploy-prometheus-git-branch))
+    branch: test-deploy-jammy
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: prometheus-release-src

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -210,7 +210,7 @@ jobs:
       trigger: true
     - get: oauth2-proxy-release
       trigger: true
-    - get: prometheus-stemcell-bionic
+    - get: prometheus-stemcell-jammy
       trigger: true
     - get: secureproxy-release
       trigger: true
@@ -225,7 +225,7 @@ jobs:
       - oauth2-proxy-release/*.tgz
       - secureproxy-release/*.tgz
       stemcells:
-      - prometheus-stemcell-bionic/*.tgz
+      - prometheus-stemcell-jammy/*.tgz
       ops_files:
       - prometheus-config/bosh/opsfiles/rules.yml
       - prometheus-config/bosh/opsfiles/staging.yml
@@ -372,6 +372,12 @@ resources:
   type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
+
+- name: prometheus-jammy-bionic
+  type: bosh-io-jammy
+  source:
+    name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
+
 
 - name: prometheus-staging-deployment
   type: bosh-deployment

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -355,9 +355,8 @@ resources:
   icon: github-circle
   type: git
   source:
-    #uri: ((cg-deploy-prometheus-git-url))
     uri: ((cg-deploy-prometheus-git-url))
-    branch: test-deploy-jammy
+    branch: ((cg-deploy-prometheus-git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: prometheus-release-src

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -200,7 +200,6 @@ jobs:
   - in_parallel:
     - get: master-bosh-root-cert
     - get: prometheus-staging-config
-      passed: [set-self]
       trigger: true
     - get: common-staging
       trigger: true
@@ -259,7 +258,7 @@ jobs:
   - in_parallel:
     - get: master-bosh-root-cert
     - get: prometheus-config
-      passed: [deploy-prometheus-staging]
+      passed: [set-self, deploy-prometheus-staging]
       trigger: true
     - get: common-production
       trigger: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -199,7 +199,8 @@ jobs:
   plan:
   - in_parallel:
     - get: master-bosh-root-cert
-    - get: prometheus-staging-config
+    - get: prometheus-config
+      passed: [set-self]
       trigger: true
     - get: common-staging
       trigger: true
@@ -218,7 +219,7 @@ jobs:
   - put: prometheus-staging-deployment
     params: &deploy-params
       cert: master-bosh-root-cert/master-bosh.crt
-      manifest: prometheus-staging-config/bosh/manifest.yml
+      manifest: prometheus-config/bosh/manifest.yml
       releases:
       - prometheus-release/*.tgz
       - oauth2-proxy-release/*.tgz
@@ -226,10 +227,10 @@ jobs:
       stemcells:
       - prometheus-stemcell-jammy/*.tgz
       ops_files:
-      - prometheus-staging-config/bosh/opsfiles/rules.yml
-      - prometheus-staging-config/bosh/opsfiles/staging.yml
+      - prometheus-config/bosh/opsfiles/rules.yml
+      - prometheus-config/bosh/opsfiles/staging.yml
       vars_files:
-      - prometheus-staging-config/bosh/varsfiles/staging.yml
+      - prometheus-config/bosh/varsfiles/staging.yml
       - common-staging/staging-prometheus.yml
       - terraform-staging-yml/state.yml
   on_failure:
@@ -258,7 +259,7 @@ jobs:
   - in_parallel:
     - get: master-bosh-root-cert
     - get: prometheus-config
-      passed: [set-self, deploy-prometheus-staging]
+      passed: [deploy-prometheus-staging]
       trigger: true
     - get: common-production
       trigger: true
@@ -286,7 +287,6 @@ jobs:
       - prometheus-config/bosh/varsfiles/production.yml
       - common-production/production-prometheus.yml
       - terraform-prod-yml/state.yml
-      manifest: prometheus-config/bosh/manifest.yml
   on_failure:
     put: slack
     params:
@@ -357,14 +357,6 @@ resources:
   source:
     uri: ((cg-deploy-prometheus-git-url))
     branch: ((cg-deploy-prometheus-git-branch))
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-
-- name: prometheus-staging-config
-  icon: github-circle
-  type: git
-  source:
-    uri: ((cg-deploy-prometheus-staging-git-url))
-    branch: ((cg-deploy-prometheus-staging-git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: prometheus-release-src

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -218,7 +218,7 @@ jobs:
   - put: prometheus-staging-deployment
     params: &deploy-params
       cert: master-bosh-root-cert/master-bosh.crt
-      manifest: prometheus-config/bosh/manifest.yml
+      manifest: prometheus-staging-config/bosh/manifest.yml
       releases:
       - prometheus-release/*.tgz
       - oauth2-proxy-release/*.tgz
@@ -226,10 +226,10 @@ jobs:
       stemcells:
       - prometheus-stemcell-jammy/*.tgz
       ops_files:
-      - prometheus-config/bosh/opsfiles/rules.yml
-      - prometheus-config/bosh/opsfiles/staging.yml
+      - prometheus-staging-config/bosh/opsfiles/rules.yml
+      - prometheus-staging-config/bosh/opsfiles/staging.yml
       vars_files:
-      - prometheus-config/bosh/varsfiles/staging.yml
+      - prometheus-staging-config/bosh/varsfiles/staging.yml
       - common-staging/staging-prometheus.yml
       - terraform-staging-yml/state.yml
   on_failure:
@@ -286,6 +286,7 @@ jobs:
       - prometheus-config/bosh/varsfiles/production.yml
       - common-production/production-prometheus.yml
       - terraform-prod-yml/state.yml
+      manifest: prometheus-config/bosh/manifest.yml
   on_failure:
     put: slack
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -199,7 +199,7 @@ jobs:
   plan:
   - in_parallel:
     - get: master-bosh-root-cert
-    - get: prometheus-config
+    - get: prometheus-staging-config
       passed: [set-self]
       trigger: true
     - get: common-staging
@@ -357,6 +357,14 @@ resources:
   source:
     uri: ((cg-deploy-prometheus-git-url))
     branch: ((cg-deploy-prometheus-git-branch))
+    commit_verification_keys: ((cloud-gov-pgp-keys))
+
+- name: prometheus-staging-config
+  icon: github-circle
+  type: git
+  source:
+    uri: ((cg-deploy-prometheus-staging-git-url))
+    branch: ((cg-deploy-prometheus-staging-git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: prometheus-release-src

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -373,8 +373,8 @@ resources:
   source:
     name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
 
-- name: prometheus-jammy-bionic
-  type: bosh-io-jammy
+- name: prometheus-stemcell-jammy
+  type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update manifest to use ubuntu-jammy stemcell
- Update pipeline to use Jammy stemcell agent

## security considerations

We need to update our BOSH deployments to use Ubuntu Jammy stemcells because Ubuntu Bionic stemcell support is end of life in April
