### PR TITLE
Scale prod prometheus vm due to volume/cpu and increase cf/firehouse …

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -130,12 +130,14 @@ instance_groups:
           - targets:
             - localhost:9190
         - job_name: cf
-          scrape_interval: 1m
-          scrape_timeout: 1m
+          scrape_interval: 90s
+          scrape_timeout: 75s
           static_configs:
           - targets:
             - localhost:9193
         - job_name: firehose
+          scrape_interval: 90s
+          scrape_timeout: 75s
           static_configs:
           - targets:
             - localhost:9186

--- a/bosh/opsfiles/prod-common.yml
+++ b/bosh/opsfiles/prod-common.yml
@@ -106,7 +106,7 @@
 # instance types.
 - type: replace
   path: /instance_groups/name=prometheus/vm_type
-  value: m5.large
+  value: m5.xlarge
 - type: replace
   path: /instance_groups/name=prometheus-tooling/vm_type
   value: m5.large


### PR DESCRIPTION
…timeouts due to volume

## Changes proposed in this pull request:
- Scale prod prometheus vm form large to xlarge due to constant high CPU usage
- Increase scape intervals and timeout for cf and firehose due to volume

## security considerations
Having timely and consistent data and alerts is a require of the platform 
