### PR TITLE
Adding more prod urls for checks

### DIFF
--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -7,7 +7,10 @@ logsearch_ratio_threshold: 50
 blackbox-targets:
 - https://dashboard.fr.cloud.gov
 - https://login.fr.cloud.gov
+- https://uaa.fr.cloud.gov
 - https://api.fr.cloud.gov
+- https://logs.fr.cloud.gov
+- https://idp.fr.cloud.gov
 - https://test-java.app.cloud.gov
 - https://test-nodejs.app.cloud.gov
 - https://test-dotnet-core.app.cloud.gov


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a few more Prod URLs for TLS monitoring and alerting via Prometheus

## security considerations
After IDP incident, this allows us to monitor and alert on ELB wildcard certs that might be expiring soon that got missed
