### PR TITLE
increase interval/timeout for CF

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -130,14 +130,14 @@ instance_groups:
           - targets:
             - localhost:9190
         - job_name: cf
-          scrape_interval: 90s
-          scrape_timeout: 75s
+          scrape_interval: 2m
+          scrape_timeout: 100s
           static_configs:
           - targets:
             - localhost:9193
         - job_name: firehose
-          scrape_interval: 90s
-          scrape_timeout: 75s
+          scrape_interval: 2m
+          scrape_timeout: 100s
           static_configs:
           - targets:
             - localhost:9186


### PR DESCRIPTION
## Changes proposed in this pull request:
- Changed scrape interval for CF/Firehouse for 2 min and timeout to 100s

## Notes
On average under load during the day the scrape takes an average of 85 seconds to return but we do see higher intervals under heavier load and it causes the exporter to enter a race condition that it never serves up metrics and shows as down.

## security considerations
Keeping tab of metrics on the platform helps the operators tune the platform and find patterns of possible attacks.
