### PR TITLE
Adding more prod urls to monitor

### DIFF
--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -23,3 +23,16 @@ blackbox-targets:
 - https://api.data.gov
 - https://fire.airnow.gov
 - https://www.airnow.gov
+- https://account.fr.cloud.gov
+- https://cloud.gov
+- https://alertmanager.fr.cloud.gov
+- https://ci.fr.cloud.gov
+- https://grafana.fr.cloud.gov
+- https://logs-platform.fr.cloud.gov
+- https://opslogin.fr.cloud.gov
+- https://prometheus.fr.cloud.gov
+- https://doomsday.fr.cloud.gov
+- https://pages-staging.cloud.gov
+- https://pages.cloud.gov
+- https://admin.pages-staging.cloud.gov
+- https://admin.pages.cloud.gov


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding more prod URLs from Zap scan lists to monitor via AM

## security considerations
Allow operators to receive alerts if prod certs are going to expire soon and not caught by CI/CD
