### PR TITLE
adding in new job, rules, config for blackbox tls config

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -173,6 +173,25 @@ instance_groups:
             regex: .*
             target_label: __address__
             replacement: localhost:9115
+        - job_name: blackbox_tls
+          metrics_path: /probe
+          params:
+            module:
+            - http
+          dns_sd_configs:
+            - names: ((blackbox_tls-targets))
+              type: A
+              port: 443
+          relabel_configs:
+            - source_labels: [__address__]
+              target_label: __param_target
+              replacement: https://$1/ 
+            - target_label: __address__
+              replacement: localhost:9115
+            - source_labels: [__meta_dns_name]
+              target_label: __param_hostname 
+            - source_labels: [__meta_dns_name]
+              target_label: vhost
         - job_name: node
           file_sd_configs:
           - files:

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -277,6 +277,30 @@
         summary: Probe failing for {{$labels.instance}} for 5m
         description: Check health of {{$labels.instance}}
 
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: blackbox_tls
+    rules:
+    - alert: SSLCertExpiringSoon
+      expr: probe_ssl_earliest_cert_expiry{job="blackbox_tls"} - time() < 86400 * 25
+      for: 10m
+      labels:
+        service: blackbox_tls
+        severity: warning
+      annotations:
+        summary: SSL certificate for {{$labels.vhost}} is expiring within 25d
+        description: Renew SSL certificate for {{$labels.vhost}}
+    - alert: ProbeFailing
+      expr: probe_success{job="blackbox_tls"} < 1
+      for: 5m
+      labels:
+        service: blackbox_tls
+        severity: warning
+      annotations:
+        summary: Probe failing for {{$labels.vhost}} for 5m
+        description: Check health of {{$labels.vhost}}
+
 # CF Core - non-customer stuff.
 - type: replace
   path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-

--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -25,14 +25,15 @@ blackbox-targets:
 - https://www.airnow.gov
 - https://account.fr.cloud.gov
 - https://cloud.gov
-- https://alertmanager.fr.cloud.gov
 - https://ci.fr.cloud.gov
-- https://grafana.fr.cloud.gov
-- https://logs-platform.fr.cloud.gov
 - https://opslogin.fr.cloud.gov
-- https://prometheus.fr.cloud.gov
 - https://doomsday.fr.cloud.gov
 - https://pages-staging.cloud.gov
 - https://pages.cloud.gov
 - https://admin.pages-staging.cloud.gov
 - https://admin.pages.cloud.gov
+blackbox_tls-targets:
+- prometheus.fr.cloud.gov
+- logs-platform.fr.cloud.gov
+- alertmanager.fr.cloud.gov
+- grafana.fr.cloud.gov

--- a/bosh/varsfiles/staging.yml
+++ b/bosh/varsfiles/staging.yml
@@ -6,4 +6,15 @@ logsearch_log_count_threshold: 300
 logsearch_ratio_threshold: 50
 blackbox-targets:
 - https://api.fr-stage.cloud.gov
+- https://idp.fr-stage.cloud.gov
+- https://login.fr-stage.cloud.gov
+- https://uaa.fr-stage.cloud.gov
+- https://logs.fr-stage.cloud.gov
+- https://ci.fr-stage.cloud.gov
+- https://dashboard.fr-stage.cloud.gov
+blackbox_tls-targets:
+- graphana.fr-stage.cloud.gov
+- prometheus.fr-stage.cloud.gov
+- alertmanager.fr-stage.cloud.gov
+- logs-platform.fr-stage.cloud.gov
 opsgenie-url: https://api.opsgenie.com


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `blackbox_tls` scraper
- Define new `blackbox_tls` targets in `stage` and `prod`
- Define new `blackbox_tls` alert rule

## Notes
The `blackbox_tls` job is needed for TLS check edge cases where an SNI is needed and Host Header based checks fail - mainly on multi-rule ELB TLS listeners

## security considerations
n/a
