### PR TITLE
Removing blackbox_tls work

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -173,31 +173,6 @@ instance_groups:
             regex: .*
             target_label: __address__
             replacement: localhost:9115
-        - job_name: blackbox_tls
-          metrics_path: /probe
-          params:
-            module:
-            - http
-          dns_sd_configs:
-            - names: ((blackbox_tls-targets))
-              type: A
-              port: 443
-          relabel_configs:
-            - source_labels: [__address__]
-              regex: (.*)
-              target_label: __param_target
-              replacement: https://$1/  
-            - source_labels: [__param_target]
-              target_label: instance
-              regex: (.*)
-            - source_labels: []
-              regex: .*
-              target_label: __address__
-              replacement: localhost:9115
-            - source_labels: [__meta_dns_name]
-              target_label: __param_hostname
-            - source_labels: [__meta_dns_name]
-              target_label: vhost
         - job_name: node
           file_sd_configs:
           - files:

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -277,30 +277,6 @@
         summary: Probe failing for {{$labels.instance}} for 5m
         description: Check health of {{$labels.instance}}
 
-- type: replace
-  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
-  value:
-    name: blackbox_tls
-    rules:
-    - alert: SSLCertExpiringSoon
-      expr: probe_ssl_earliest_cert_expiry{job="blackbox_tls"} - time() < 86400 * 25
-      for: 10m
-      labels:
-        service: blackbox_tls
-        severity: warning
-      annotations:
-        summary: SSL certificate for {{$labels.vhost}} is expiring within 25d
-        description: Renew SSL certificate for {{$labels.vhost}}
-    - alert: ProbeFailing
-      expr: probe_success{job="blackbox_tls"} < 1
-      for: 5m
-      labels:
-        service: blackbox_tls
-        severity: warning
-      annotations:
-        summary: Probe failing for {{$labels.vhost}} for 5m
-        description: Check health of {{$labels.vhost}}
-
 # CF Core - non-customer stuff.
 - type: replace
   path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-

--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -32,8 +32,3 @@ blackbox-targets:
 - https://pages.cloud.gov
 - https://admin.pages-staging.cloud.gov
 - https://admin.pages.cloud.gov
-blackbox_tls-targets:
-- prometheus.fr.cloud.gov
-- logs-platform.fr.cloud.gov
-- alertmanager.fr.cloud.gov
-- grafana.fr.cloud.gov

--- a/bosh/varsfiles/staging.yml
+++ b/bosh/varsfiles/staging.yml
@@ -12,9 +12,4 @@ blackbox-targets:
 - https://logs.fr-stage.cloud.gov
 - https://ci.fr-stage.cloud.gov
 - https://dashboard.fr-stage.cloud.gov
-blackbox_tls-targets:
-- graphana.fr-stage.cloud.gov
-- prometheus.fr-stage.cloud.gov
-- alertmanager.fr-stage.cloud.gov
-- logs-platform.fr-stage.cloud.gov
 opsgenie-url: https://api.opsgenie.com


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pulling out changes for `blackbox_tls`
- Pull out `logs-platform`, `grafana`, `prometheus`, and `alertmanager` from monitoring configs

## Notes
For the `prod` and `stage` websites above, prometheus `blackbox exporter module` throws a 403 based on a bug in the `blackbox_exporter` that is not [patched currently](https://github.com/prometheus/blackbox_exporter/issues/886).

Doomsday is still monitoring the certs for these sites as well for now

## security considerations
n/a
