### PR TITLE
Adding new oauth for grafana so we can upgrade prometheus

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -104,12 +104,12 @@ instance_groups:
           external_url: https://prometheus.((domain))
         rule_files:
         - /var/vcap/jobs/bosh_alerts/*.alerts.yml
-        - /var/vcap/jobs/cloudfoundry_alerts/cf_cells.alerts.yml
-        - /var/vcap/jobs/cloudfoundry_alerts/cf_diego.alerts.yml
-        - /var/vcap/jobs/cloudfoundry_alerts/cf_doppler.alerts.yml
-        - /var/vcap/jobs/cloudfoundry_alerts/cf_routers.alerts.yml
-        - /var/vcap/jobs/cloudfoundry_alerts/prometheus_cf_exporter.alerts.yml
-        - /var/vcap/jobs/cloudfoundry_alerts/prometheus_firehose_exporter.alerts.yml
+        - /var/vcap/jobs/cloudfoundry_alerts-attic/cf_cells.alerts.yml
+        - /var/vcap/jobs/cloudfoundry_alerts-attic/cf_diego.alerts.yml
+        - /var/vcap/jobs/cloudfoundry_alerts-attic/cf_doppler.alerts.yml
+        - /var/vcap/jobs/cloudfoundry_alerts-attic/cf_routers.alerts.yml
+        - /var/vcap/jobs/cloudfoundry_alerts-attic/prometheus_cf_exporter.alerts.yml
+        - /var/vcap/jobs/cloudfoundry_alerts-attic/prometheus_firehose_exporter.alerts.yml
         - /var/vcap/jobs/elasticsearch_alerts/*.alerts.yml
         - /var/vcap/jobs/concourse_alerts/*.alerts.yml
         - /var/vcap/jobs/prometheus_alerts/*.alerts.yml
@@ -219,7 +219,7 @@ instance_groups:
           deployment_name: cf-((environment))
         metrics:
           environment: ((environment))
-  - name: firehose_exporter
+  - name: firehose_exporter-attic
     release: prometheus
     properties:
       firehose_exporter:
@@ -273,7 +273,7 @@ instance_groups:
           network: ((environment))-concourse
           query: '*'
     
-  - name: cloudfoundry_alerts
+  - name: cloudfoundry_alerts-attic
     release: prometheus
   - name: elasticsearch_alerts
     release: prometheus
@@ -303,10 +303,21 @@ instance_groups:
         session:
           cookie_secure: "true"
         auth:
-          anonymous:
+          generic_oauth:
+            name: Cloud.gov Operator Opslogin
             enabled: true
-            org_role: Admin
-            org_name: cloud.gov
+            allow_sign_up: true
+            auto_login: true
+            client_id: ((oauth-proxy-client-id))
+            client_secret: ((oauth-proxy-client-secret))
+            scopes: openid
+            auth_url: https://opslogin.fr.cloud.gov/oauth/authorize
+            token_url: https://opslogin.fr.cloud.gov/oauth/token
+            api_url: https://opslogin.fr.cloud.gov/userinfo
+            tls_client_ca: "((lets_encrypt_ca.certificate))"
+            tls_client_cert: "((/toolingbosh/opsuaa/uaa_ssl.certificate))"
+            tls_client_key: "((/toolingbosh/opsuaa/uaa_ssl.private_key))"
+            tls_skip_verify_insecure: false
           basic:
             enabled: false
         dashboards:
@@ -317,7 +328,7 @@ instance_groups:
           dashboard_files:
           - /var/vcap/jobs/bosh_dashboards/*.json
           - /var/vcap/jobs/system_dashboards/*.json
-          - /var/vcap/jobs/cloudfoundry_dashboards/*.json
+          - /var/vcap/jobs/cloudfoundry_dashboard-attics/*.json
           - /var/vcap/jobs/probe_dashboards/*.json
           - /var/vcap/jobs/elasticsearch_dashboards/*.json
           - /var/vcap/jobs/concourse_dashboards/*.json
@@ -326,7 +337,7 @@ instance_groups:
     release: prometheus
   - name: system_dashboards
     release: prometheus
-  - name: cloudfoundry_dashboards
+  - name: cloudfoundry_dashboard-attics
     release: prometheus
   - name: probe_dashboards
     release: prometheus

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -2,7 +2,7 @@ cg-deploy-prometheus-git-branch: main
 cg-deploy-prometheus-git-url: https://github.com/cloud-gov/cg-deploy-prometheus.git
 
 prometheus-release-git-branch: master
-prometheus-release-version-filter: v28.*
+prometheus-release-version-filter: v29.*
 prometheus-release-git-url: https://github.com/bosh-prometheus/prometheus-boshrelease
 
 pipeline-tasks-git-branch: main


### PR DESCRIPTION
## Changes proposed in this pull request:
- Prometheus bump to 29
- Use Grafana's new oauth

## security considerations
This makes sure we get prometheus updates