### PR TITLE
Add uptime monitoring alert & test CDN blackbox targets

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -382,3 +382,19 @@
         summary: ClamAV scan alert for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}
         description: ClamAV alert for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}} - check the logs on the instance to establish threat and follow procedures
 
+# HTTPS uptime alerts
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
+  value:
+    name: uptime-monitor
+    rules:
+    - alert: UptimeMonitorFailed
+      expr: probe_http_status_code{job="blackbox"} != 200
+      for: 5m
+      labels:
+        service: uptime
+        severity: warning
+      annotations:
+        summary: Uptime check failed (non-200 response) for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}
+        description: Uptime check failed (non-200 response) for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}. Check the infrastructure serving {{$labels.instance}} for outages or issues.
+

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -396,5 +396,5 @@
         severity: warning
       annotations:
         summary: Uptime check failed (non-200 response) for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}
-        description: Uptime check failed (non-200 response) for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}. Check the infrastructure serving {{$labels.instance}} for outages or issues.
+        description: Uptime check failed (non-200 response) for {{$labels.instance}} in {{$labels.environment}}/{{$labels.deployment}}. Runbook - https://github.com/cloud-gov/internal-docs/blob/main/docs/runbooks/Metrics-and-Alerting/uptime-monitoring.md#uptimemonitorfailed
 

--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -32,3 +32,4 @@ blackbox-targets:
 - https://pages.cloud.gov
 - https://admin.pages-staging.cloud.gov
 - https://admin.pages.cloud.gov
+- https://test-cdn.fr.cloud.gov

--- a/bosh/varsfiles/staging.yml
+++ b/bosh/varsfiles/staging.yml
@@ -12,4 +12,5 @@ blackbox-targets:
 - https://logs.fr-stage.cloud.gov
 - https://ci.fr-stage.cloud.gov
 - https://dashboard.fr-stage.cloud.gov
+- https://test-cdn.fr-stage.cloud.gov
 opsgenie-url: https://api.opsgenie.com


### PR DESCRIPTION
Related to https://github.com/cloud-gov/private/issues/888

## Changes proposed in this pull request:

- Add blackbox targets in staging/prod for test CDN app
- Add alert for non-200 responses for blackbox targets for 5 minutes

## security considerations

Uptime monitoring provides a minor security benefit, since awareness of downtime can increase response time to incidents
