### PR TITLE
updating alert for pages proxy

### DIFF
--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -112,29 +112,29 @@
   value: m5.large
 
 # add some prod-only rules
-# monitor Federalist proxy
+# monitor Pages proxy
 - type: replace
   path: /instance_groups/name=prometheus/jobs/name=prometheus2/properties/prometheus/custom_rules?/-
   value:
-    name: federalist-proxy
+    name: pages-proxy
     rules:
-    - alert: FederalistProxyUnhealthy
+    - alert: PagesProxyUnhealthy
       # get all the cf application instances with matching org, space, and app IDs. 
       # Subtract from that all the instances with matching org, space, app ids with state Running.
       # Take the minimum of that, and see if it's more than zero
-      expr: min(cf_application_instances{organization_id="((federalist_org_id))", space_id="((federalist_proxy_space_id))", application_id="((federalist_proxy_app_id))"} - cf_application_instances_running{state=~"STARTED", organization_id="((federalist_org_id))", space_id="((federalist_proxy_space_id))", application_id="((federalist_proxy_app_id))"} ) > 0
+      expr: min(cf_application_instances{organization_id="((pages_org_id))", space_id="((pages_proxy_space_id))", application_id="((pages_proxy_app_id))"} - cf_application_instances_running{state=~"STARTED", organization_id="((pages_org_id))", space_id="((pages_proxy_space_id))", application_id="((pages_proxy_app_id))"} ) > 0
       for: 5m
       labels:
         severity: warning
       annotations:
-        summary: "Federalist proxy app unhealthy"
-        description: "Reach out to Federalist"
-    - alert: FederalistProxyCrashed
+        summary: "Pages proxy app unhealthy"
+        description: "Reach out to Pages"
+    - alert: PagesProxyCrashed
       # get all the cf application instances with matching org, space, and app IDs in state started. If there are zero, alert. 
-      expr: sum(cf_application_instances_running{organization_id="((federalist_org_id))", space_id="((federalist_proxy_space_id))", application_id="((federalist_proxy_app_id))"}) == 0
+      expr: sum(cf_application_instances_running{organization_id="((pages_org_id))", space_id="((pages_proxy_space_id))", application_id="((pages_proxy_app_id))"}) == 0
       for: 5m
       labels:
         severity: critical
       annotations:
-        summary: "Federalist proxy app crashed"
-        description: "Reach out to Federalist"
+        summary: "Pages proxy app crashed"
+        description: "Reach out to Pages"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update alert name/details
- Change app to now be `pages-proxy-production`

## Notes

New credhub values for `prometheus-production` with updated names are in place.  Leaving older Federalist variables in place for now until we know this change is rolled out.

## security considerations
Alerting that the proper app is down allows timely resolution to the issue
