### PR TITLE
Add error trapping for cloudwatch metrics

### DIFF
--- a/ci/aws-rds-storage/rds_disk_space.py
+++ b/ci/aws-rds-storage/rds_disk_space.py
@@ -37,7 +37,13 @@ def get_free_space(db_instance):
         EndTime=datetime.datetime.now(),
         Period=60,
         Statistics=['Average'],)
-    free_space = min([(lambda x: x['Average'])(datapoint) for datapoint in cloudtrail_response['Datapoints']])
+
+    try:
+        free_space = min([(lambda x: x['Average'])(datapoint) for datapoint in cloudtrail_response['Datapoints']])
+    except:
+        #print(f'Probably a new born db, could not pull cloudwatch metrics, setting value to 100000000: {db_instance}')
+        free_space = 100000000
+        
     return free_space
 
 def get_prometheus_metrics(db_to_storage):

--- a/ci/aws-rds-storage/rds_disk_space.py
+++ b/ci/aws-rds-storage/rds_disk_space.py
@@ -41,7 +41,7 @@ def get_free_space(db_instance):
     try:
         free_space = min([(lambda x: x['Average'])(datapoint) for datapoint in cloudtrail_response['Datapoints']])
     except:
-        #print(f'Probably a new born db, could not pull cloudwatch metrics, setting value to 100000000: {db_instance}')
+        # Probably a new born db, could not pull cloudwatch metrics, setting value to 100000000
         free_space = 100000000
         
     return free_space


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add error trapping for cloudwatch metrics retrieval
- Timing issue between when a new RDS instance is created and 5 minute lookback window for disk stats
- Error see was `ValueError: min() arg is an empty sequence`

## security considerations
Should reduce the number of false positive concourse job failures
