### PR TITLE
give logsearch backup a little more slack

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -132,6 +132,7 @@
         summary: Logsearch archive to index ratio on environment {{$labels.environment}} is too low
         description: Logsearch archive to index ratio on environment {{$labels.environment}} has been too low for 30m.  The S3 archival process or the ES ingest process may not be working.  See the archival and ingestor instances in the logsearch deployment in case any of their components need restarting.
     - alert: LogsearchBackupExpired
+      # TODO: get the backup checks running on better time, then change this back to 60 * 30
       expr: time() - max(logsearch_backup_timestamp) > 60 * 45
       for: 5m
       labels:

--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -132,14 +132,14 @@
         summary: Logsearch archive to index ratio on environment {{$labels.environment}} is too low
         description: Logsearch archive to index ratio on environment {{$labels.environment}} has been too low for 30m.  The S3 archival process or the ES ingest process may not be working.  See the archival and ingestor instances in the logsearch deployment in case any of their components need restarting.
     - alert: LogsearchBackupExpired
-      expr: time() - max(logsearch_backup_timestamp) > 60 * 30
+      expr: time() - max(logsearch_backup_timestamp) > 60 * 45
       for: 5m
       labels:
         service: logsearch-backup
         severity: warning
       annotations:
         summary: Logsearch timestamp on environment {{$labels.environment}} is too old
-        description: Logsearch timestamp on environment {{$labels.environment}} has been too old for 5m.  This indicates that the logsearch checks in https://github.com/18F/cg-deploy-logsearch/blob/master/ci/check-backup.sh have not run recently, so we do not have good data to alert on.
+        description: Logsearch timestamp on environment {{$labels.environment}} has been too old for 5m.  This indicates that the logsearch checks in https://github.com/cloud-gov/cg-deploy-logsearch/blob/main/ci/check-backup.sh have not run recently, so we do not have good data to alert on.
 
 # Nessus alerts
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- update the time we consider a backup timestamp "too old" from 30 minutes to 45 minutes. As Concourse has gotten busier, the backup checks now run a more than a few minutes late, but that should be ok for now
- update link to point to the actual home for the repo


I think the real long-term fix here is to move these checks out of Concourse and onto prometheus or the maintenance VM as a cron job. 

## security considerations
Having stale backups is bad, and this increases the chances that backups will go stale without notice
On the other hand, this alert fires false alarms so frequently that people don't look at it anyway, so improving the signal:noise ratio here is a win