### PR TITLE
Modify threshold for persistent disk and cpu alerts to reduce noise

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -258,14 +258,15 @@ instance_groups:
           threshold: 78
           evaluation_time: 10m
         job_persistent_disk_full:
-          threshold: 78
+          threshold: 85
           evaluation_time: 10m
         job_predict_persistent_disk_full:
-          threshold: 78
+          threshold: 85
           evaluation_time: 10m
         # set really high because this is never really actionable as-is
         job_high_cpu_load:
           threshold: 100
+          evaluation_time: 30m
   - name: bosh-dns-aliases
     release: bosh-dns-aliases
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bump persistent disk alerts to closer to default, default is 90.  The logsearch deployments will allow the data nodes to scale to 85% before preventing new shards from being placed.  One of the nodes is at 85% as reported by `curl -s 'localhost:9200/_cat/allocation?v'` but prometheus sees the disk at 81%.  So setting the prometheus alert threshold to 85% will silence the perfectly healthy logsearch data nodes with a couple percent to spare.
- Bumping the high cpu warnings (seen mostly on diego cells) from the default of 10m to 30m since there basically isn't anything we can do or would do as a result of this warning.
- Left the ephemeral disk alerts alone, the only one I found was from when I really did fill a disk on an `emptvm`, so these aren't noisy

## Security considerations
Trying to reduce the noise so real issues are better seen.
