### PR TITLE
Add yaml anchor back

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -47,11 +47,13 @@ jobs:
           GATEWAY_HOST: http://prometheus-production.service.cf.internal
     on_failure:
       put: slack
-      params:
-        <<: *slack-failure-params
+      params: &slack-failure-params
         text: |
           :x: FAILED to check remaining storage on AWS RDS instances
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel-failure))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
   - name: aws-iam-check-keys
     serial_groups: [production]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removed the yaml anchor by accident with https://github.com/cloud-gov/deploy-prometheus/pull/293, this puts it back on the next highest survivor 
- Part of https://github.com/cloud-gov/private/issues/2623
-

## security considerations
Puts yaml config back for slack alert
