### PR TITLE
Add aide_violation_count to list of federated params

### DIFF
--- a/bosh/opsfiles/prod-common.yml
+++ b/bosh/opsfiles/prod-common.yml
@@ -10,7 +10,7 @@
       - '{__name__=~"bosh_.*"}'
       - '{__name__=~"node_.*"}'
       - '{__name__=~"nessus_.*"}'
-      - '{__name__=~"concourse.*"}'
+      - '{__name__=~"aide_.*"}'
     static_configs:
     - targets:
       - prometheus-tooling.service.cf.internal:9090

--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -10,7 +10,7 @@
       - '{__name__=~"bosh_.*"}'
       - '{__name__=~"node_.*"}'
       - '{__name__=~"nessus_.*"}'
-      - '{__name__=~"concourse.*"}'
+      - '{__name__=~"aide_.*"}'
     static_configs:
     - targets:
       - prometheus-tooling.service.cf.internal:9090


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add aide_violation_count to list of federated params
- Removes "concourse" since there are no jobs/metrics with that naming convention
- Tested manually already
- Part of https://github.com/cloud-gov/product/issues/2836


## security considerations
Let's us know about more aide violations in tooling
