### PR TITLE
Make subscription_id unique amongst deployments

### DIFF
--- a/bosh/manifest-single.yml
+++ b/bosh/manifest-single.yml
@@ -207,7 +207,7 @@ instance_groups:
           client_id: ((firehose-client-id))
           client_secret: ((firehose-client-secret))
         doppler:
-          subscription_id: prometheus
+          subscription_id: prometheus-((environment))
         filter:
           deployments: cf-production
           events: ContainerMetric, CounterEvent, ValueMetric

--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -230,7 +230,7 @@ instance_groups:
           client_id: ((firehose-client-id))
           client_secret: ((firehose-client-secret))
         doppler:
-          subscription_id: prometheus
+          subscription_id: prometheus-((environment))
         metrics:
           environment: ((environment))
         logging:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Make subscription_id unique amongst deployments, otherwise scrapes become inconsistent when attached to the same CF firehose
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
No changes to security footprint
