### PR TITLE
Adding custom alert for logs-platform

### DIFF
--- a/bosh/opsfiles/rules.yml
+++ b/bosh/opsfiles/rules.yml
@@ -440,7 +440,7 @@
         service: logsearch-platform
         severity: critical
       annotations:
-        summary: "logsearch-platform node {{$labels.bosh_job_name}}/{{$labels.bosh_job_id}} index {{$labels.bosh_job_index}} disk is over 85% used"
+        summary: "logsearch-platform node {{$labels.bosh_job_name}}/{{$labels.bosh_job_id}} index {{$labels.bosh_job_index}} disk is over 80% used"
         description: Review deployment and indexes and see if index and/or scaling operations need to take place for growth
     - alert: logsearch_platform_disk_warning
       expr: bosh_job_persistent_disk_percent{bosh_deployment="logsearch-platform"} > 83
@@ -449,5 +449,5 @@
         service: logsearch-platform
         severity: warning
       annotations:
-        summary: "logsearch-platform node {{$labels.bosh_job_name}}/{{$labels.bosh_job_id}} index {{$labels.bosh_job_index}} disk is over 88% used"
+        summary: "logsearch-platform node {{$labels.bosh_job_name}}/{{$labels.bosh_job_id}} index {{$labels.bosh_job_index}} disk is over 83% used"
         description: Review deployment and indexes and see if index and/or scaling operations need to take place for growth


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add custom alert for logsearch-platform disk

## NOTE

There is about a +3% drift between what BOSH Vitals/Metrics shows vs how elastic sees the disk usage so the lower value from the default BOSH alert  is required to not cause elastic to stop ingesting.

## security considerations
n/a
