### PR TITLE
Adjusting scrape interval for bosh_exporter

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -126,7 +126,7 @@ instance_groups:
           - targets:
             - localhost:9091
         - job_name: bosh
-          scrape_interval: 1m
+          scrape_interval: 2m
           scrape_timeout: 1m
           static_configs:
           - targets:

--- a/bosh/opsfiles/prod-common.yml
+++ b/bosh/opsfiles/prod-common.yml
@@ -42,7 +42,7 @@
             - targets:
               - localhost:9090
           - job_name: bosh
-            scrape_interval: 1m
+            scrape_interval: 2m
             scrape_timeout: 1m
             static_configs:
             - targets:

--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -42,7 +42,7 @@
             - targets:
               - localhost:9090
           - job_name: bosh
-            scrape_interval: 1m
+            scrape_interval: 2m
             scrape_timeout: 1m
             static_configs:
             - targets:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moving prometheus and prometheus tooling bosh_exporter scraper from `1m` to `2m` to reduce burden on the tooling and production bosh directors

## security considerations
n/a
