### PR TITLE
Configure BBS in cf_exporter

### DIFF
--- a/bosh/opsfiles/cf_exporter.yml
+++ b/bosh/opsfiles/cf_exporter.yml
@@ -1,0 +1,9 @@
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=cf_exporter/properties/cf_exporter?/bbs?
+  value: 
+    api_url: ((diego_bbs_api_url))
+    ca: ((diego_bbs_client.ca))
+    cert: ((diego_bbs_client.certificate))
+    key: ((diego_bbs_client.private_key))
+    skip_ssl_verify: true
+    timeout: 55

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -331,6 +331,7 @@ jobs:
           ops_files:
             - prometheus-config/bosh/opsfiles/rules.yml
             - prometheus-config/bosh/opsfiles/staging.yml
+            - prometheus-config/bosh/opsfiles/cf_exporter.yml
           vars_files:
             - prometheus-config/bosh/varsfiles/staging.yml
             - common-staging/staging-prometheus.yml
@@ -374,6 +375,7 @@ jobs:
           ops_files:
             - prometheus-config/bosh/opsfiles/rules.yml
             - prometheus-config/bosh/opsfiles/production.yml
+            - prometheus-config/bosh/opsfiles/cf_exporter.yml
           vars_files:
             - prometheus-config/bosh/varsfiles/production.yml
             - common-production/production-prometheus.yml
@@ -423,6 +425,7 @@ jobs:
             - prometheus-config/bosh/workshop/alerting.yml
             - prometheus-config/bosh/workshop/scrapers.yml
             - prometheus-config/bosh/workshop/grafana-roles.yml
+            - prometheus-config/bosh/opsfiles/cf_exporter.yml
           vars_files:
             - prometheus-config/bosh/workshop/workshop-vars.yml
             - terraform-prod-yml/state.yml
@@ -469,6 +472,7 @@ jobs:
             - prometheus-config/bosh/pages/alerting.yml
             - prometheus-config/bosh/pages/scrapers.yml
             - prometheus-config/bosh/pages/grafana-roles.yml
+            - prometheus-config/bosh/opsfiles/cf_exporter.yml
           vars_files:
             - prometheus-config/bosh/pages/pages-vars.yml
             - terraform-prod-yml/state.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Configure BBS values in the `cf_exporter` job, should work now that v31.1.0 has been released
- the `diego_bbs_api_url` and `diego_bbs_client.*` values for staging, production, workshop and pages has been added already to credhub in tooling
- Part of https://github.com/cloud-gov/private/issues/2810

## security considerations
Values are stored in credhub
