### PR TITLE
increase root and ephmeral disk for single instance types

### DIFF
--- a/bosh/manifest-single.yml
+++ b/bosh/manifest-single.yml
@@ -241,6 +241,8 @@ instance_groups:
   persistent_disk_type: production-prometheus-small
   vm_extensions:
   - ((environment))-prometheus-lb
+  - 10GB_ephemeral_disk
+  - 10GB_root_disk
   stemcell: default
   azs: ((azs))
   networks:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increase ephemeral disk and data for single prometheus installations (pages and workshop)  


## Notes
`/var/vcap/packages` has been growing as releases get larger so 5 GB is no longer enough when doing all in one prometheus deployments

## security considerations
n/a
