### PR TITLE
Bump ephemeral disk for single vm deployments

### DIFF
--- a/bosh/manifest-single.yml
+++ b/bosh/manifest-single.yml
@@ -36,6 +36,8 @@ instance_groups:
   instances: 1
   vm_type: m6i.large
   persistent_disk_type: ((environment))-prometheus-large
+  vm_extensions:
+  - 10GB_ephemeral_disk
   stemcell: default
   azs: ((azs))
   networks:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bump ephemeral disk for single vm deployments
- Part of https://github.com/cloud-gov/private/issues/2982
-

## security considerations
Expands ephemeral disk.  Risk of tearing a hole in space/time is minimal, though not zero
