### PR TITLE
Bumping ephemeral disk for single nodes from 10 to 15

### DIFF
--- a/bosh/manifest-single.yml
+++ b/bosh/manifest-single.yml
@@ -243,7 +243,7 @@ instance_groups:
   persistent_disk_type: production-prometheus-small
   vm_extensions:
   - ((environment))-prometheus-lb
-  - 10GB_ephemeral_disk
+  - 15GB_ephemeral_disk
   - 10GB_root_disk
   stemcell: default
   azs: ((azs))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move single node ephemeral disk from 10 to 15 GB due to more non-persistent disk data usage and swap

## security considerations
n/a
