### PR TITLE
fix: add retry logic to pip installs in CI task files

### DIFF
--- a/ci/aws-iam-check-keys.yml
+++ b/ci/aws-iam-check-keys.yml
@@ -12,12 +12,19 @@ inputs:
 run:
   path: sh
   args:
-  - -c
+  - -ec
   - |
+    retry() {
+      n=1; max=3; delay=15
+      until "$@"; do
+        if [ $n -ge $max ]; then echo "Failed after $max attempts: $*"; return 1; fi
+        echo "Attempt $n failed, retrying in ${delay}s..."; sleep $delay; n=$((n+1))
+      done
+    }
     cd prometheus-config/ci/aws-iam-check-keys
     # note: this installs into system python. This is ok in an ephemeral container
     # but do not copy this locally!
-    python3 -m pip install -r requirements.txt
+    retry python3 -m pip install --retries 3 --timeout 60 -r requirements.txt
     python3 find_stale_keys.py
 params:
   AWS_DEFAULT_REGION:

--- a/ci/aws-rds-storage.yml
+++ b/ci/aws-rds-storage.yml
@@ -7,12 +7,19 @@ inputs:
 run:
   path: sh
   args:
-  - -c
+  - -ec
   - |
+    retry() {
+      n=1; max=3; delay=15
+      until "$@"; do
+        if [ $n -ge $max ]; then echo "Failed after $max attempts: $*"; return 1; fi
+        echo "Attempt $n failed, retrying in ${delay}s..."; sleep $delay; n=$((n+1))
+      done
+    }
     cd prometheus-config/ci/aws-rds-storage
     # note: this installs into system python. This is ok in an ephemeral container
     # but do not copy this locally!
-    python3 -m pip install -r requirements.txt
+    retry python3 -m pip install --retries 3 --timeout 60 -r requirements.txt
     python3 rds_disk_space.py
 
 params:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Wraps pip install calls in a retry function (3 attempts, 15s delay) to handle transient 502 errors from files.pythonhosted.org.
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
Adds retry logic, no impact to boundary